### PR TITLE
improved styles of styled-jsx

### DIFF
--- a/src/components/IconsWrapper.tsx
+++ b/src/components/IconsWrapper.tsx
@@ -24,11 +24,17 @@ const HatenaSvg: React.FC<ClassProps> = props => {
   return <svg className={props.class} xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.47 0C22.42 0 24 1.58 24 3.53v16.94c0 1.95-1.58 3.53-3.53 3.53H3.53C1.58 24 0 22.42 0 20.47V3.53C0 1.58 1.58 0 3.53 0h16.94zm-3.705 14.47c-.78 0-1.41.63-1.41 1.41s.63 1.414 1.41 1.414 1.41-.645 1.41-1.425-.63-1.41-1.41-1.41zM8.61 17.247c1.2 0 2.056-.042 2.58-.12.526-.084.976-.222 1.32-.412.45-.232.78-.564 1.02-.99s.36-.915.36-1.48c0-.78-.21-1.403-.63-1.87-.42-.48-.99-.734-1.74-.794.66-.18 1.156-.45 1.456-.81.315-.344.465-.824.465-1.424 0-.48-.103-.885-.3-1.26-.21-.36-.493-.645-.883-.87-.345-.195-.735-.315-1.215-.405-.464-.074-1.29-.12-2.474-.12H5.654v10.486H8.61zm.736-4.185c.705 0 1.185.088 1.44.262.27.18.39.495.39.93 0 .405-.135.69-.42.855-.27.18-.765.254-1.44.254H8.31v-2.297h1.05zm8.656.706v-7.06h-2.46v7.06H18zM8.925 9.08c.71 0 1.185.08 1.432.24.245.16.367.435.367.83 0 .38-.13.646-.39.804-.265.154-.747.232-1.452.232h-.57V9.08h.615z' /></svg>
 }
 
-const HomeIconStyle = css`
+const commonStyle = css`
+.icons{
+  display: flex;
+  flex-direction: row;
+  z-index: 100;
+}
+
 .icon{
   position: relative;
-  display: inline-block;
   text-decoration: none;
+  border-radius: 50%;
   width: 2rem;
   height: 2rem;
   margin: .5rem;
@@ -41,14 +47,62 @@ const HomeIconStyle = css`
   height: 1.9rem;
 }
 
+.icon[aria-expanded='false']{
+  display: none;
+}
+
+:global(.react-icons),
+:global(.homeIconSvg){
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  fill: #424242;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 @media( min-width: 960px ){
-  .icon{
+  .icon {
     width: 2.25rem;
     height: 2.25rem;
   }
-  .icon:active{
+  .icon:active {
     width: 2.15rem;
     height: 2.15rem;
+  }
+  :global(.react-icons),
+  :global(.homeIconSvg){
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+`
+
+const homeStyle = css`
+.icon {
+  position: relative;
+  display: inline-block;
+  text-decoration: none;
+  margin: .5rem;
+  background-color: #EEE;
+  border-radius: 50%;
+}
+`
+
+const columnStyle = css`
+.icons {
+  position: fixed;
+  bottom: .5rem;
+  right: .5rem;
+}
+
+@media( min-width: 960px ){
+  .icons{
+    display: flex;
+    flex-direction: column;
+    left: 91%;
+    bottom: 3rem;
   }
 }
 `
@@ -86,53 +140,11 @@ export const HomeIcons: React.FC<Props> = ({ openSearch }) => {
           <IconContext.Provider value={{ className: 'react-icons' }}><FaTwitter /></IconContext.Provider>
         </a>
       </div>
-      <style jsx>{HomeIconStyle}</style>
+      <style jsx>{commonStyle}</style>
+      <style jsx>{homeStyle}</style>
     </>
   )
 }
-
-const BlogIconsStyle = css`
-  .icons{
-    display: flex;
-    flex-direction: row;
-    position: fixed;
-    bottom: .5rem;
-    right: .5rem;
-    z-index: 100;
-  }
-
-  .icon{
-    position: relative;
-    text-decoration: none;
-    border-radius: 50%;
-    width: 2rem;
-    height: 2rem;
-    margin: .5rem;
-    background-color: #EEE;
-    border-radius: 50%;
-  }
-
-  .icon:hover, .icon:active{
-    border: 2px solid #424242;
-  }
-  
-  .icon[aria-expanded='false']{
-    display: none;
-  }
-
-  @media( min-width: 960px ){
-    .icons{
-      display: flex;
-      flex-direction: column;
-      left: 91%;
-      bottom: 3rem;
-    }
-    .icon{
-      width: 2.25rem;
-      height: 2.25rem;
-    }
-  }
-`
 
 export const PostsIcons: React.FC<Props> = ({ openSearch }) => {
   return (
@@ -149,7 +161,8 @@ export const PostsIcons: React.FC<Props> = ({ openSearch }) => {
           </a>
         </Link>
       </div>
-      <style jsx>{BlogIconsStyle}</style>
+      <style jsx>{commonStyle}</style>
+      <style jsx>{columnStyle}</style>
     </>
   )
 }  
@@ -200,7 +213,8 @@ export const PostIcons: React.FC<PostProps> = ({ title, id, tags }) => {
           <IconContext.Provider value={{ className: 'react-icons' }}><MdMoreHoriz /></IconContext.Provider>
         </a>
       </div>
-      <style jsx>{BlogIconsStyle}</style>
+      <style jsx>{commonStyle}</style>
+      <style jsx>{columnStyle}</style>
     </>    
   )
 }  
@@ -220,7 +234,8 @@ export const TagsIcons: React.FC = () => {
           </a>
         </Link>
       </div>
-      <style jsx>{BlogIconsStyle}</style>
+      <style jsx>{commonStyle}</style>
+      <style jsx>{columnStyle}</style>
     </>    
   )
 }  
@@ -254,7 +269,8 @@ export const TagIcons: React.FC = ()  => {
           <IconContext.Provider value={{ className: 'react-icons' }}><MdMoreHoriz /></IconContext.Provider>
         </a>
       </div>
-      <style jsx>{BlogIconsStyle}</style>
+      <style jsx>{commonStyle}</style>
+      <style jsx>{columnStyle}</style>
     </>    
   )
 }  

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -83,84 +83,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           font-weight: 700;
         }
 
-        code {
-          display: inline-block;
-          margin: .1rem .3rem;
-          padding: 0 .4rem;
-          background-color: #555;
-          color: #EEE;
-        }
-
-        pre {
-          border: .8px solid grey;
-          border-radius: 0.25rem;
-          display: block;
-          white-space: pre;
-          background-color: #1E1E1E;
-          width: 100%;
-          max-width: 1000px;
-          margin: 1rem 0;
-          overflow: auto;
-        }
-
         source, img {
           width: 100%;
           height: auto;
           object-fit: cover;
-        }
-
-        blockquote {
-          color: #BBB;
-          border-left: 5px solid #BBB;
-          margin: 1rem 0;
-          padding: .5rem 0 .5rem .5rem;
-        }
-
-        .react-icons, .homeIconSvg{
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          fill: #424242;
-          width: 1.25rem;
-          height: 1.25rem;
-        }
-
-        .heading-link{
-          color: #EEE;
-          border-bottom: .1rem solid #50CAF9;
-        }
-        .heading-link:hover{
-          color: #50CAF9;
-        }
-        .heading-link:hover::before{
-          color: #50CAF9;
-        }
-
-        h2 > .heading-link{
-          font-size: 1.5rem;
-        }
-        h2 > .heading-link::before{
-          content: '## ';
-        }
-        h3 > .heading-link{
-          font-size: 1.17rem;
-        }
-        h3 > .heading-link::before{
-          content: '### ';
-        }
-        h4 > .heading-link{
-          font-size: 1rem;
-        }
-        h4 > .heading-link::before{
-          content: '#### ';
-        }
-
-        @media ( min-width: 960px ){
-          .react-icons, .homeIconSvg{
-            width: 1.5rem;
-            height: 1.5rem;
-          }
         }
       `}</style>
     </>

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -67,6 +67,63 @@ h1{
 .tag:hover, .tag:active{
   background-color: #424242;
 }
+
+:global(.heading-link){
+  color: #EEE;
+  border-bottom: .1rem solid #50CAF9;
+}
+:global(.heading-link):hover{
+  color: #50CAF9;
+}
+:global(.heading-link):hover::before{
+  color: #50CAF9;
+}
+
+:global(h2 > .heading-link){
+  font-size: 1.5rem;
+}
+:global(h2 > .heading-link)::before{
+  content: '## ';
+}
+:global(h3 > .heading-link){
+  font-size: 1.17rem;
+}
+:global(h3 > .heading-link)::before{
+  content: '### ';
+}
+:global(h4 > .heading-link){
+  font-size: 1rem;
+}
+:global(h4 > .heading-link)::before{
+  content: '#### ';
+}
+
+code :global(.markdown.content) {
+  display: inline-block;
+  margin: .1rem .3rem;
+  padding: 0 .4rem;
+  background-color: #555;
+  color: #EEE;
+}
+
+pre :global(.markdown.content){
+  border: .8px solid grey;
+  border-radius: 0.25rem;
+  display: block;
+  white-space: pre;
+  background-color: #1E1E1E;
+  width: 100%;
+  max-width: 1000px;
+  margin: 1rem 0;
+  overflow: auto;
+}
+
+blockquote :global(.markdown.content){
+  color: #BBB;
+  border-left: 5px solid #BBB;
+  margin: 1rem 0;
+  padding: .5rem 0 .5rem .5rem;
+}
 `
 
 type Props = {
@@ -94,7 +151,7 @@ const Component: React.FC<Props> = ({ id, title, create, tags, image, content })
           <meta property='og:url' content={`${blogConfig.baseUrl}/posts/${id}/` } />
           <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/vs2015.min.css' />
         </Head>
-        <article className='content'>
+        <article className='markdown content'>
         <PostIcons title={title} id={id} tags={tags} />
           <h1>{title}</h1>
           <div>


### PR DESCRIPTION
## apply one-off global selectors of styled-jsx
like below

```css
:global(h2 > .heading-link)::before{
  content: '## ';
}
```

plz refer 

- ["One-off global selectors in READMD of styled-jsx"](https://github.com/vercel/styled-jsx#one-off-global-selectors)
- [dmm inside technology - 堅牢なCSSをReactに手軽に実装できるstyled-jsx](https://inside.dmm.com/entry/2018/05/14/react-styled-jsx)