### PR TITLE
Change algolia from react-instantsearch-dom to react-instantsearch-hooks-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "prism-react-renderer": "^1.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-instantsearch-dom": "^6.38.0",
+        "react-instantsearch-hooks-web": "^6.38.0",
         "react-use": "^17.4.0",
         "rehype-slug": "^5.1.0",
         "remark-comment": "^1.0.0",
@@ -170,6 +170,20 @@
         "@algolia/logger-common": "4.14.2",
         "@algolia/requester-common": "4.14.2"
       }
+    },
+    "node_modules/@algolia/ui-components-highlight-vdom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ui-components-highlight-vdom/-/ui-components-highlight-vdom-1.2.1.tgz",
+      "integrity": "sha512-IlYgIaCUEkz9ezNbwugwKv991oOHhveyq6nzL0F1jDzg1p3q5Yj/vO4KpNG910r2dwGCG3nEm5GtChcLnarhFA==",
+      "dependencies": {
+        "@algolia/ui-components-shared": "1.2.1",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@algolia/ui-components-shared": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ui-components-shared/-/ui-components-shared-1.2.1.tgz",
+      "integrity": "sha512-a7mYHf/GVQfhAx/HRiMveKkFvHspQv/REdG+C/FIOosiSmNZxX7QebDwJkrGSmDWdXO12D0Qv1xn3AytFcEDlQ=="
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.1",
@@ -1090,6 +1104,11 @@
       "integrity": "sha512-J/rMZa7RqiH/rT29TEVZO4nBoDP9XJOjnbbIofg7GQKs4JIduEO3WLpte+6WeUz/TcrXKlY+bM7FYrp8yFB+3g==",
       "dev": true
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.50.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
+      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
+    },
     "node_modules/@types/hast": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -1097,6 +1116,11 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/hogan.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hogan.js/-/hogan.js-3.0.1.tgz",
+      "integrity": "sha512-D03i/2OY7kGyMq9wdQ7oD8roE49z/ZCZThe/nbahtvuqCNZY9T2MfedOWyeBdbEpY2W8Gnh/dyJLdFtUCOkYbg=="
     },
     "node_modules/@types/js-cookie": {
       "version": "2.2.7",
@@ -1147,6 +1171,11 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/react": {
       "version": "18.0.25",
@@ -1324,6 +1353,11 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -1882,11 +1916,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
-    },
-    "node_modules/classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -3627,11 +3656,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "dependencies": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/hogan.js/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/husky": {
       "version": "8.0.1",
@@ -3743,6 +3798,28 @@
       "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
       "dependencies": {
         "css-in-js-utils": "^2.0.0"
+      }
+    },
+    "node_modules/instantsearch.js": {
+      "version": "4.49.1",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.49.1.tgz",
+      "integrity": "sha512-iYGRF+UujVaxn/twZXTfYkI+wc1luCiHZ/ozBME5MiVoit0wBvtERGUFR01uauZJSXCCXmjBg/JJojPngf7mAA==",
+      "dependencies": {
+        "@algolia/events": "^4.0.1",
+        "@algolia/ui-components-highlight-vdom": "^1.2.1",
+        "@algolia/ui-components-shared": "^1.2.1",
+        "@types/google.maps": "^3.45.3",
+        "@types/hogan.js": "^3.0.0",
+        "@types/qs": "^6.5.3",
+        "algoliasearch-helper": "^3.11.1",
+        "hogan.js": "^3.0.2",
+        "htm": "^3.0.0",
+        "preact": "^10.10.0",
+        "qs": "^6.5.1 < 6.10",
+        "search-insights": "^2.1.0"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6"
       }
     },
     "node_modules/internal-slot": {
@@ -6258,6 +6335,20 @@
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
       "dev": true
     },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6452,6 +6543,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6859,6 +6951,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
+      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -6935,6 +7036,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6971,6 +7073,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -7058,48 +7171,41 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
-    "node_modules/react-instantsearch-core": {
+    "node_modules/react-instantsearch-hooks": {
       "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.38.0.tgz",
-      "integrity": "sha512-Y5denvptL+qDOHY3LxipULNun8f3t2WeO9UdiWJd9FER1vn1VBrDdSyZ5b+idxqVWhSeVbncbf98zr7EW/kFvA==",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks/-/react-instantsearch-hooks-6.38.0.tgz",
+      "integrity": "sha512-P/SX99udPeaL4up4U4aKaBsiYS7kgOJo5UxG/oTqJXnGpKPqnxZAqIDG3vs8qhXeRAv3PU2H3WMj4og54L5tAg==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.11.1",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0"
+        "instantsearch.js": "^4.47.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 5",
-        "react": ">= 16.3.0 < 19"
+        "react": ">= 16.8.0 < 19"
       }
     },
-    "node_modules/react-instantsearch-dom": {
+    "node_modules/react-instantsearch-hooks-web": {
       "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.38.0.tgz",
-      "integrity": "sha512-yE0y9U1GCPZ/Jqzbd2BHTdx83/DYIEbXqAt7a+a5TLi4qQgwjTpVrtAkqzhT8f1/TRhNqu0wYAT4HFixVsW8FA==",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.38.0.tgz",
+      "integrity": "sha512-gNMv+Ep4q5DL/TDP+nWZrCRRDnamme5rdLuNjK1w0eZkzXBjoD7ngsEzJoFKs7SmmBFpOXNCgUNvAucbNLOM9w==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.11.1",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "6.38.0"
+        "instantsearch.js": "^4.47.0",
+        "react-instantsearch-hooks": "6.38.0"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 5",
-        "react": ">= 16.3.0 < 19",
-        "react-dom": ">= 16.3.0 < 19"
+        "react": ">= 16.8.0 < 19",
+        "react-dom": ">= 16.8.0 < 19"
       }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
@@ -7614,6 +7720,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.2.1.tgz",
+      "integrity": "sha512-JDfVGZbKqTtiKVZjAVbkNw9C9f0ib80yx6Ea17M3z4RvPmuD0GYWXuFwA9++dpbreBEMH4TC3lQ29Zq7O4b5oA==",
+      "engines": {
+        "node": ">=8.16.0"
       }
     },
     "node_modules/section-matter": {
@@ -10802,6 +10916,20 @@
         "@algolia/requester-common": "4.14.2"
       }
     },
+    "@algolia/ui-components-highlight-vdom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ui-components-highlight-vdom/-/ui-components-highlight-vdom-1.2.1.tgz",
+      "integrity": "sha512-IlYgIaCUEkz9ezNbwugwKv991oOHhveyq6nzL0F1jDzg1p3q5Yj/vO4KpNG910r2dwGCG3nEm5GtChcLnarhFA==",
+      "requires": {
+        "@algolia/ui-components-shared": "1.2.1",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "@algolia/ui-components-shared": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ui-components-shared/-/ui-components-shared-1.2.1.tgz",
+      "integrity": "sha512-a7mYHf/GVQfhAx/HRiMveKkFvHspQv/REdG+C/FIOosiSmNZxX7QebDwJkrGSmDWdXO12D0Qv1xn3AytFcEDlQ=="
+    },
     "@azu/format-text": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.1.tgz",
@@ -11505,6 +11633,11 @@
       "integrity": "sha512-J/rMZa7RqiH/rT29TEVZO4nBoDP9XJOjnbbIofg7GQKs4JIduEO3WLpte+6WeUz/TcrXKlY+bM7FYrp8yFB+3g==",
       "dev": true
     },
+    "@types/google.maps": {
+      "version": "3.50.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
+      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
+    },
     "@types/hast": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -11512,6 +11645,11 @@
       "requires": {
         "@types/unist": "*"
       }
+    },
+    "@types/hogan.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hogan.js/-/hogan.js-3.0.1.tgz",
+      "integrity": "sha512-D03i/2OY7kGyMq9wdQ7oD8roE49z/ZCZThe/nbahtvuqCNZY9T2MfedOWyeBdbEpY2W8Gnh/dyJLdFtUCOkYbg=="
     },
     "@types/js-cookie": {
       "version": "2.2.7",
@@ -11562,6 +11700,11 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/react": {
       "version": "18.0.25",
@@ -11690,6 +11833,11 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
       "version": "8.8.1",
@@ -12104,11 +12252,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
-    },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "client-only": {
       "version": "0.0.1",
@@ -13422,11 +13565,32 @@
         "space-separated-tokens": "^1.0.0"
       }
     },
+    "hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "requires": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew=="
+        }
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "husky": {
       "version": "8.0.1",
@@ -13500,6 +13664,25 @@
       "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
       "requires": {
         "css-in-js-utils": "^2.0.0"
+      }
+    },
+    "instantsearch.js": {
+      "version": "4.49.1",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.49.1.tgz",
+      "integrity": "sha512-iYGRF+UujVaxn/twZXTfYkI+wc1luCiHZ/ozBME5MiVoit0wBvtERGUFR01uauZJSXCCXmjBg/JJojPngf7mAA==",
+      "requires": {
+        "@algolia/events": "^4.0.1",
+        "@algolia/ui-components-highlight-vdom": "^1.2.1",
+        "@algolia/ui-components-shared": "^1.2.1",
+        "@types/google.maps": "^3.45.3",
+        "@types/hogan.js": "^3.0.0",
+        "@types/qs": "^6.5.3",
+        "algoliasearch-helper": "^3.11.1",
+        "hogan.js": "^3.0.2",
+        "htm": "^3.0.0",
+        "preact": "^10.10.0",
+        "qs": "^6.5.1 < 6.10",
+        "search-insights": "^2.1.0"
       }
     },
     "internal-slot": {
@@ -15249,6 +15432,14 @@
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
       "dev": true
     },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -15402,7 +15593,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -15690,6 +15882,11 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "preact": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
+      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw=="
+    },
     "prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -15743,6 +15940,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15773,6 +15971,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -15835,39 +16038,32 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
-    "react-instantsearch-core": {
+    "react-instantsearch-hooks": {
       "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.38.0.tgz",
-      "integrity": "sha512-Y5denvptL+qDOHY3LxipULNun8f3t2WeO9UdiWJd9FER1vn1VBrDdSyZ5b+idxqVWhSeVbncbf98zr7EW/kFvA==",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks/-/react-instantsearch-hooks-6.38.0.tgz",
+      "integrity": "sha512-P/SX99udPeaL4up4U4aKaBsiYS7kgOJo5UxG/oTqJXnGpKPqnxZAqIDG3vs8qhXeRAv3PU2H3WMj4og54L5tAg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.11.1",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0"
+        "instantsearch.js": "^4.47.0",
+        "use-sync-external-store": "^1.0.0"
       }
     },
-    "react-instantsearch-dom": {
+    "react-instantsearch-hooks-web": {
       "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.38.0.tgz",
-      "integrity": "sha512-yE0y9U1GCPZ/Jqzbd2BHTdx83/DYIEbXqAt7a+a5TLi4qQgwjTpVrtAkqzhT8f1/TRhNqu0wYAT4HFixVsW8FA==",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.38.0.tgz",
+      "integrity": "sha512-gNMv+Ep4q5DL/TDP+nWZrCRRDnamme5rdLuNjK1w0eZkzXBjoD7ngsEzJoFKs7SmmBFpOXNCgUNvAucbNLOM9w==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.11.1",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.2",
-        "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "6.38.0"
+        "instantsearch.js": "^4.47.0",
+        "react-instantsearch-hooks": "6.38.0"
       }
     },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "react-universal-interface": {
       "version": "0.6.2",
@@ -16248,6 +16444,11 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
       "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
+    },
+    "search-insights": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.2.1.tgz",
+      "integrity": "sha512-JDfVGZbKqTtiKVZjAVbkNw9C9f0ib80yx6Ea17M3z4RvPmuD0GYWXuFwA9++dpbreBEMH4TC3lQ29Zq7O4b5oA=="
     },
     "section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prism-react-renderer": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-instantsearch-dom": "^6.38.0",
+    "react-instantsearch-hooks-web": "^6.38.0",
     "react-use": "^17.4.0",
     "rehype-slug": "^5.1.0",
     "remark-comment": "^1.0.0",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,10 +1,8 @@
 import type { NextPage } from 'next'
-import { useRouter } from 'next/router'
-import { Configure, InstantSearch } from 'react-instantsearch-dom'
 import { styled } from 'goober'
 
 import { Layout } from 'components/layouts'
-import { searchClient, CustomSearchBox, CustomStateResults, CustomHits } from 'components/search'
+import { AlgoliaSearch } from 'components/search'
 
 const PostsWrapper = styled('div')`
   padding: 1rem;
@@ -16,26 +14,15 @@ const H1 = styled('h1')`
   text-align: center;
 `
 
-const algoliaIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX || ''
-
-const Component: NextPage = () => {
-  const router = useRouter()
-  const qs = router.query.q as string
-  const urlToSearchState = decodeURI(qs || '')
-
+const Page: NextPage = () => {
   return (
     <Layout title="search posts" path="/search/">
       <PostsWrapper>
         <H1>Search</H1>
-        <InstantSearch indexName={algoliaIndex} searchClient={searchClient}>
-          <Configure hitsPerPage={10} />
-          <CustomSearchBox defaultRefinement={urlToSearchState} />
-          <CustomStateResults />
-          <CustomHits />
-        </InstantSearch>
+        <AlgoliaSearch />
       </PostsWrapper>
     </Layout>
   )
 }
 
-export default Component
+export default Page

--- a/src/components/search/hits.tsx
+++ b/src/components/search/hits.tsx
@@ -1,22 +1,24 @@
-import { HitsProvided, Hit } from 'react-instantsearch-core'
-import { connectHits } from 'react-instantsearch-dom'
-import { PostCard } from 'components/post-card'
-import { CustomPoweredBy } from '.'
-import { PostType, FrontMatterType } from 'types/markdown'
+import type { UseHitsProps } from 'react-instantsearch-hooks-web';
+import { useHits } from 'react-instantsearch-hooks-web';
 
-interface HitProps extends Pick<FrontMatterType, 'title' | 'create' | 'update' | 'tags'> {
+import type { PostType, FrontMatterType } from 'types/markdown'
+import { PostCard } from 'components/post-card'
+import { CustomPoweredBy } from './powered-by'
+
+type HitProps = Pick<FrontMatterType, 'title' | 'create' | 'update' | 'tags'> & {
   id: PostType['fileName']
 }
 
-const Hits: React.FC<HitsProvided<Hit<HitProps>>> = ({ hits }) => {
+const Hits: React.FC<UseHitsProps<HitProps>> = (props) => {
+  const { hits } = useHits<HitProps>(props);
   return (
     <>
-      {hits.map((hit) => (
-        <PostCard slug={hit.id} title={hit.title} date={hit.update || hit.create} tags={hit.tags} key={hit.id} />
+      {hits.map(({ id, title, update, create, tags }) => (
+        <PostCard slug={id} title={title} date={update || create} tags={tags} key={id} />
       ))}
-      {!!hits.length && <CustomPoweredBy />}
+      <CustomPoweredBy />
     </>
   )
 }
 
-export const CustomHits = connectHits(Hits)
+export const CustomHits = Hits

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,7 +1,53 @@
+import { useRef } from 'react';
+import type { UseSearchBoxProps } from 'react-instantsearch-hooks-web';
+import { InstantSearch, Configure } from 'react-instantsearch-hooks-web'
+import { history } from 'instantsearch.js/es/lib/routers';
+
 import { searchClient } from './search-client'
 import { CustomSearchBox } from './search-box'
-import { CustomStateResults } from './search-results'
+import { CustomSearchResults } from './search-results'
 import { CustomHits } from './hits'
-import { CustomPoweredBy } from './powered-by'
 
-export { searchClient, CustomSearchBox, CustomStateResults, CustomHits, CustomPoweredBy }
+const algoliaIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX || ''
+
+// [Sync your URLs with React InstantSearch Hooks | Algolia](https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/react-hooks/#basic-urls)
+const routing = {
+  router: history(),
+  stateMapping: {
+    stateToRoute(uiState: any) {
+      const indexUiState = uiState[algoliaIndex];
+      return {
+        q: indexUiState.query,
+      };
+    },
+    routeToState(routeState: any) {
+      return {
+        [algoliaIndex]: {
+          query: routeState.q,
+        },
+      };
+    },
+  },
+};
+
+export const AlgoliaSearch: React.FC = () => {
+  const timerId = useRef<ReturnType<typeof setTimeout>>();
+  const queryHook: UseSearchBoxProps["queryHook"] = (query, search) => {
+    if (timerId.current) {
+      clearTimeout(timerId.current);
+    }
+    timerId.current = setTimeout(()=> search(query), 1000)
+  }
+
+  return (
+    <InstantSearch indexName={algoliaIndex} searchClient={searchClient} routing={routing}>
+      <Configure hitsPerPage={10} analytics={false} />
+      <CustomSearchBox
+        queryHook={queryHook}
+        placeholder="Search with English (1000ms delay)"
+      />
+      <CustomSearchResults />
+      <CustomHits />
+    </InstantSearch>
+  )
+}

--- a/src/components/search/powered-by.tsx
+++ b/src/components/search/powered-by.tsx
@@ -1,16 +1,17 @@
 import { styled } from 'goober'
-import { connectPoweredBy } from 'react-instantsearch-dom'
+import { usePoweredBy } from 'react-instantsearch-hooks-web'
 
 import { AlgoliaIcon } from 'components/icons'
 
-interface Props {
+type Props = {
   className?: string
 }
 
 const Component: React.FC<Props> = (props) => {
   const { className } = props
+  const { url } = usePoweredBy();
   return (
-    <a className={className} href="https://www.algolia.com" target="_blank" rel="noopener noreferrer">
+    <a className={className} href={url} target="_blank" rel="noopener noreferrer">
       <AlgoliaIcon />
     </a>
   )
@@ -24,4 +25,4 @@ const ContainerComponent: React.FC = () => {
   return <StyledComponent />
 }
 
-export const CustomPoweredBy = connectPoweredBy(ContainerComponent)
+export const CustomPoweredBy = ContainerComponent;

--- a/src/components/search/search-client.ts
+++ b/src/components/search/search-client.ts
@@ -1,3 +1,5 @@
+import type { MultipleQueriesQuery, MultipleQueriesResponse } from '@algolia/client-search'
+import type { SearchClient } from 'algoliasearch/lite'
 import algoliasearch from 'algoliasearch/lite'
 
 const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || ''
@@ -5,18 +7,25 @@ const searchKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_KEY || ''
 
 const algoliaClient = algoliasearch(appId, searchKey)
 
-export const searchClient = {
-  search(requests: any) {
-    if (requests.every(({ params }: { params: any }) => !params.query)) {
-      return Promise.resolve({
+export const searchClient: SearchClient = {
+  ...algoliaClient,
+  search: <SearchResponse>(requests: Readonly<MultipleQueriesQuery[]>) => {
+    if (requests.every(({ params }) => !params?.query)) {
+      return Promise.resolve<MultipleQueriesResponse<SearchResponse>>({
         results: requests.map(() => ({
           hits: [],
           nbHits: 0,
           nbPages: 0,
+          page: 0,
           processingTimeMS: 0,
+          hitsPerPage: 0,
+          exhaustiveNbHits: false,
+          query: '',
+          params: '',
         })),
-      })
+      });
     }
+
     return algoliaClient.search(requests)
   },
 }

--- a/src/components/search/search-results.tsx
+++ b/src/components/search/search-results.tsx
@@ -1,38 +1,35 @@
-import { connectStateResults } from 'react-instantsearch-dom'
-import { SearchState, AllSearchResults, AlgoliaError } from 'react-instantsearch-core'
+import { useInstantSearch } from 'react-instantsearch-hooks-web';
 import { styled } from 'goober'
 
-interface PassedProps {
-  error: AlgoliaError
-  searchState: SearchState
-  searchResults: AllSearchResults
-}
-
-interface Props extends PassedProps {
+type Props = {
   className?: string
 }
 
 const Component = (props: Props) => {
-  const { className, error, searchState, searchResults } = props
-  const hasResults = searchResults && searchResults.nbHits !== 0
-  const nbHits = searchResults && searchResults.nbHits
+  const { className } = props;
+  const { results, error, status } = useInstantSearch();
+  const { nbHits, query } = results;
 
   if (error) {
     return <div className={className + ' error'}>SEARCH_ERROR: {error.message}</div>
   }
 
-  if (!searchState.query?.length) {
+  if (status === 'loading' || status === 'stalled') {
+    return <div className={className}>Loading ...</div>
+  }
+
+  if (!query?.length) {
     return <div className={className} />
   }
 
-  if (hasResults) {
+  if (nbHits) {
     return (
       <div className={className}>
-        {nbHits} results were found for {searchState.query}.
+        {nbHits} results were found for {query}.
       </div>
     )
   } else {
-    return <div className={className}>No results for {searchState.query}</div>
+    return <div className={className}>No results for {query}</div>
   }
 }
 
@@ -44,6 +41,6 @@ const StyledComponent = styled(Component)`
   }
 `
 
-const ContainerComponent: React.FC<PassedProps> = (props) => <StyledComponent {...props} />
+const ContainerComponent: React.FC = () => <StyledComponent />
 
-export const CustomStateResults = connectStateResults(ContainerComponent)
+export const CustomSearchResults = ContainerComponent


### PR DESCRIPTION
Change algolia from react-instantsearch-dom to react-instantsearch-hooks-web

# related issues
Fixes #91 

# Changes proposed in this pull request
- remove react-instantsearch-dom
- install react-instantsearch-hooks-web and modify components with this hooks.

## the background (as memo)
- in detail, read [Migrate algolia from react-instantsearch-dom to react-instantsearch-hooks · Issue #91 · oriverk/blog.oriverk.dev](https://github.com/oriverk/blog.oriverk.dev/issues/91)
